### PR TITLE
Array XSS + tests for array and object

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -47,7 +47,7 @@ function arrayToString(array, options) {
                 arrayString += element;
                 break;
             default:
-                arrayString += `"${String(element)}"`;
+                arrayString += serialize(element);
                 break;
         }
     }

--- a/tests/string.js
+++ b/tests/string.js
@@ -26,6 +26,12 @@ test("Array", t => {
     t.is(result, expected);
 });
 
+test("XSS Array", t=> {
+    const array =  ["</script>", ["</script>"]]
+    const result = stringit(array);
+    t.false(result.includes("</script>"));
+})
+
 test("String", t => {
     let str = "foobar";
 
@@ -53,6 +59,17 @@ test("Object", t => {
     return thing;
 },"aString":"foobar","aArray":[1,2,3,4,5]}`;
     t.is(result, expected);
+});
+
+test("XSS Object", t => {
+    const objectt = {
+        aString: "</script>",
+        aObject: {
+            aString: "</script>"
+        }
+    }
+    const result = stringit(objectt);
+    t.false(result.includes("</script>"));
 });
 
 test("Big", t => {


### PR DESCRIPTION
Looks like there's 4 potential vectors: object, array, function, and string.

This should fix arrays but I think functions are fundamentally insecure because escaping them would break legitimate code. For example, escaping `lessThan(a, b) { return a < b }` would make the `<` escaped and noninterpretable.

This currently breaks on my page but I can't figure out a way to effectively fix.
```javascript
 res.renderVue('profile.vue', { test: function() {return "</script>"}, req.vueOptions);
```

I would never pass such a function anyways but might be worth mentioning in docs?

In the context of express-vue I don't think raw strings are ever passed through but I was able to use https://github.com/yahoo/xss-filters in lieu of [String() in scriptToString()](https://github.com/danmademe/js-to-string/blob/bbfa03e5a5769b0b3c87547ab007ac682b39f450/lib/string.js#L161)